### PR TITLE
Added FAQ support for VCOMP140.dll  in win64

### DIFF
--- a/mv_main.html
+++ b/mv_main.html
@@ -116,6 +116,7 @@
                 <div id="faq">
                     <div class="updatelog_header text-warning">FAQ</div>
                     <ul class="decimallist">
+                        <li><kbd>win64 : VCOMP140.DLL</kbd> You may need to download this for windows:  <a href="https://www.microsoft.com/en-ca/download/details.aspx?id=48145"> Visual C++ Redistributable for Visual Studio 2015</a></li>
                         <li><kbd>win64 : VCOMP100.DLL</kbd> You may need to download this for windows:  <a href="https://www.microsoft.com/en-us/download/details.aspx?id=26999"> Microsoft Visual C++ 2010 SP1 Redistributable Package (x64) </a></li>
                         <li><kbd>macOS : unable to open the app</kbd>: go to  Security and Privacy panel to allow the app open.</li>
                         <li><kbd>macOS : Black screen</kbd>: move magicavoxel.app outside the folder and then move it back.</li>


### PR DESCRIPTION
Some x64 systems require `VCOMP140.dll` to run mega-voxels version `0.90` and up

Added FAQ support on main page for `VCOMP140.dll` missing in Windows x64 systems 